### PR TITLE
Edit benefits-checklist.hugo.html to fix glyph issue

### DIFF
--- a/component-library/components/design-system/column/benefits-checklist/benefits-checklist.hugo.html
+++ b/component-library/components/design-system/column/benefits-checklist/benefits-checklist.hugo.html
@@ -16,7 +16,9 @@
     <ul class="list-unstyled">
       {{ range .items }}        
         <li class="d-flex mb-4">
-          <span class="h2 fa-solid fa-{{ $icon }} wvu-b-accent-text me-3 mt-1"></span>
+          <div class="h2 wvu-b-accent-text me-3 mt-1">
+            <span class="fa-solid fa-{{ $icon }}"></span>
+          </span>
           <div>
             {{ with .title }}
               <h3 class="h4 mb-0">{{ . }}</h3>


### PR DESCRIPTION
The glyphs for this component are not displaying correctly. I tested this version in DevTools on the Law staging site and it seemed to fix the issue.

**Example site:** [https://law.static.wvu.edu/](https://law.static.wvu.edu/)

<img width="1123" height="470" alt="Screenshot 2026-04-29 at 12 16 36 PM" src="https://github.com/user-attachments/assets/035feb38-819c-457b-a452-b409ff4fc842" />
